### PR TITLE
Workaround ExtUtils::Liblist stripping link library arguments.

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -1,4 +1,5 @@
 use ExtUtils::MakeMaker;
+use ExtUtils::Liblist qw();
 use Config;
 
 # Attempt to avoid the incorrect 'FAIL' reports from Chris Williams' broken NetBSD smoker(s).
@@ -41,6 +42,32 @@ $defines .= " -DLONGLONG2IV_IS_OK"
 
 $defines .= " -DLONG2IV_IS_OK"
   if $Config{ivsize} >= $Config{longsize};
+
+# Default version of Liblist strips -l params it can't find
+# in lib-path, which strips -l params that might be "compiler provided"
+# https://github.com/Perl-Toolchain-Gang/ExtUtils-MakeMaker/issues/277
+# https://rt.cpan.org/Ticket/Display.html?id=116520
+#
+# This simply assumes any such stripping is wrong and optimisitically reinserts them.
+if ( defined &ExtUtils::Liblist::ext ) {
+  warn "Patching ExtUtils::Liblist::ext\n";
+  my $orig = \&ExtUtils::Liblist::ext;
+  no warnings 'redefine';
+  *ExtUtils::Liblist::ext = sub {
+      my ( @result ) = $orig->(@_);
+      # Always make sure -lm is there as we anchor in front of -lm
+      if ( $result[2] !~ /-lm/ ) {
+        warn "Reinserting stripped -lm\n";
+        $result[2] .= ' -lm';
+      }
+      # Then insert -lquadmath in front of any such -lm
+      if ( $result[2] !~ /-lquadmath/ ) {
+        warn "Reinsterting stripped -lquadmath\n";
+        $result[2] =~ s{-lm}{-lquadmath -lm};
+      }
+      return @result;
+  };
+}
 
 my %options = %{
 {


### PR DESCRIPTION
As per https://github.com/Perl-Toolchain-Gang/ExtUtils-MakeMaker/issues/277 ,
EU:L does the wrong thing and assumes its missing, even when it is not.

On older GCC's this appears to have worked by magic, as it looks like
the `#include` directive anywhere in the source automatically activated
the link-library being injected by the compiler.

But since at least GCC 5.4, omitting an `-lquadmath` directive results
in a failed compiliation

And apparently, on some targets, the libraries `-lquadmath` and `-lm` may
not actually physically exist, but are faked into existence by the
compiler, and EU:L will always make the wrong choice, and this will
break compilation on those targets.

Hence, ensuring `-lm` is present is also done in this commit.

@leont @haarg  # Sanity check request
